### PR TITLE
"pip install -e ." does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ source .venv/bin/activate
 Install
 
 ```bash
-pip install -e .
+pip install -r requirements.txt
 ```
 
 Set environment for OPENAI API Key, optionally for Lanchain API for langsmith


### PR DESCRIPTION
~/dev/sparql-langchain$ pip install -e .
ERROR: File "setup.py" not found. Directory cannot be installed in editable mode: /home/user/dev/sparql-langchain (A "pyproject.toml" file was found, but editable mode currently requires a setup.py based build.)